### PR TITLE
Make IDA an optional dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,9 @@ endif()
 install(TARGETS bindiff RUNTIME DESTINATION bindiff-prefix)
 
 # IDA Pro plugins
-add_subdirectory(ida)
+if(IdaSdk_FOUND)
+  add_subdirectory(ida)
+endif(IdaSdk_FOUND)
 
 # Utility programs. For now, only contains a tool to modify the BinDiff
 # config from the installer/package scripts.

--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ The following build dependencies are required:
 *   GCC 9 or a recent version of Clang on Linux/macOS. On Windows, use the
     Visual Studio 2019 compiler and the Windows SDK for Windows 10.
 *   Git 1.8 or higher
-*   IDA Pro only: IDA SDK 8.0 or higher (unpack into `deps/idasdk`)
 *   Dependencies that will be downloaded:
     *   Abseil, GoogleTest, Protocol Buffers (3.14), and SQLite3
     *   Binary Ninja SDK
+
+The following build dependencies are optional:
+*   IDA Pro only: IDA SDK 8.0 or higher (unpack into `deps/idasdk`)
 
 The general build steps are the same on Windows, Linux and macOS. The following
 shows the commands for Linux.
@@ -124,6 +126,18 @@ Finally, invoke the actual build. Binaries will be placed in
 cmake --build build/out --config Release
 (cd build/out; ctest --build-config Release --output-on-failure)
 cmake --install build/out --config Release
+```
+
+### Building without IDA
+
+To build without IDA, simply change the above configuration step to
+
+```bash
+cmake -S . -B build/out -G Ninja \
+  -DCMAKE_BUILD_TYPE=Release \
+  -DCMAKE_INSTALL_PREFIX=build/out \
+  -DBINDIFF_BINEXPORT_DIR=build/binexport \
+  -DBINEXPORT_ENABLE_IDAPRO=OFF
 ```
 
 ### Java GUI and yFiles

--- a/cmake/BinDiffDeps.cmake
+++ b/cmake/BinDiffDeps.cmake
@@ -29,6 +29,6 @@ if(NOT sqlite_POPULATED)
 endif()
 
 # Setup IDA SDK. Uses FindIdaSdk.cmake from BinExport
-find_package(IdaSdk REQUIRED)
+find_package(IdaSdk)
 
 find_package(Protobuf 3.14 REQUIRED) # Make protobuf_generate_cpp available


### PR DESCRIPTION
This fix works by making find_package(IdaSdk) into an optional dependency.

For every CMake [find_package](https://cmake.org/cmake/help/v3.28/command/find_package.html) call, CMake creates a PackageName_FOUND variable.

The same variable can be checked when the add_subdirectory command is being called.

TODO: Documenting in the README could use some work

Closes #26

# Note

Need some help with testing the codebase as I don't have access to IDA myself.  
But theoretically, the code here should work.