### PR TITLE
Fix building issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ cmake -S . -B build/out -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=build/out \
   -DBINDIFF_BINEXPORT_DIR=build/binexport \
-  "-DIdaSdk_ROOT_DIR=${PWD}build/idasdk"
+  "-DIdaSdk_DIR=${PWD}/build/idasdk"
 ```
 
 Finally, invoke the actual build. Binaries will be placed in

--- a/cmake/BinDiffDeps.cmake
+++ b/cmake/BinDiffDeps.cmake
@@ -31,4 +31,4 @@ endif()
 # Setup IDA SDK. Uses FindIdaSdk.cmake from BinExport
 find_package(IdaSdk)
 
-find_package(Protobuf 3.14 REQUIRED) # Make protobuf_generate_cpp available
+find_package(Protobuf 4.25 REQUIRED) # Make protobuf_generate_cpp available


### PR DESCRIPTION
This fix is aimed to fix building dependency error, which is occurring on Ubuntu 22.04.

1. `README.md`: The CMake configure option has changed, but the README hasn't updated.
2. `BinDiffDeps.cmake`: A lower version of Protobuf has some outdated JsonPrintOptions API, pls refer to 0bea27a.
