### PR TITLE
Fix UnmatchedFunctionsChooserPrimary::get_ea

### DIFF
--- a/ida/unmatched_functions_chooser.cc
+++ b/ida/unmatched_functions_chooser.cc
@@ -41,7 +41,7 @@ size_t UnmatchedFunctionsChooserPrimary::get_count() const {
 }
 
 ea_t UnmatchedFunctionsChooserPrimary::get_ea(size_t n) const {
-  return Plugin::instance()->results()->GetMatchDescription(n).address_primary;
+  return Plugin::instance()->results()->GetUnmatchedDescriptionPrimary(n).address;
 }
 
 Results::UnmatchedDescription UnmatchedFunctionsChooserPrimary::GetDescription(


### PR DESCRIPTION
Fixed navigation bug when double-clicking on Primary Unmatched function address