### PR TITLE
Fix for installer failing on ARM mac mini sonoma 14.4.1

### DIFF
--- a/packaging/dmg/Scripts/postinstall
+++ b/packaging/dmg/Scripts/postinstall
@@ -23,6 +23,9 @@ CONFIG_FILE="/Library/Application Support/BinDiff/bindiff.json"
 LOGGED_IN_UID=$(id -u "${USER}")
 log "LOGGED_IN_UID: ${LOGGED_IN_UID}"
 
+# If the /usr/local/bin directory does not exist, create it.
+ls /usr/local/bin || mkdir /usr/local/bin
+
 BUNDLE_DIR="${APP_DIR}/BinDiff.app/Contents"
 for exe in \
   bindiff \


### PR DESCRIPTION
Hello i wanted to submit this fix for the post install script. On my new mac mini i was not able to successfully run the installer due to the /usr/local/bin directory not existing. Here are the logs from my failed install. Hopefully this can help.


```
024-05-05 10:15:25-07 latortuga0x71s-Mac-mini installd[783]: PackageKit (package_script_service): Preparing to execute script "./postinstall" in /private/tmp/PKInstallSandbox.BnVJnR/Scripts/com.google.security.zynamics.bindiff.ZHScW1
2024-05-05 10:15:25-07 latortuga0x71s-Mac-mini package_script_service[1151]: PackageKit: Preparing to execute script "postinstall" in /tmp/PKInstallSandbox.BnVJnR/Scripts/com.google.security.zynamics.bindiff.ZHScW1
2024-05-05 10:15:25-07 latortuga0x71s-Mac-mini package_script_service[1151]: Set responsibility to pid: 1603, responsible_path: /System/Library/CoreServices/Installer.app/Contents/MacOS/Installer
2024-05-05 10:15:25-07 latortuga0x71s-Mac-mini package_script_service[1151]: Hosted team responsibility for script set to team:(EQHXZ8M8AV)
2024-05-05 10:15:25-07 latortuga0x71s-Mac-mini package_script_service[1151]: PackageKit: Executing script "postinstall" in /tmp/PKInstallSandbox.BnVJnR/Scripts/com.google.security.zynamics.bindiff.ZHScW1
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini package_script_service[1151]: ./postinstall: ln: /usr/local/bin/: No such file or directory
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini package_script_service[1151]: PackageKit: Hosted team responsible for script has been cleared.
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini package_script_service[1151]: Responsibility set back to self.
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini install_monitor[1607]: Re-included: /Applications, /Library, /System, /bin, /private, /sbin, /usr
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini installd[783]: PackageKit: releasing backupd
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini installd[783]: PackageKit: allow user idle system sleep
2024-05-05 10:15:26-07 latortuga0x71s-Mac-mini installd[783]: PackageKit: Install Failed: Error Domain=PKInstallErrorDomain Code=112 "An error occurred while running scripts from the package “Install BinDiff.pkg”." UserInfo={NSFilePath=./postinstall, NSURL=file:///Users/latortuga0x71/Desktop/Install%20BinDiff.pkg#BinDiff.pkg, PKInstallPackageIdentifier=com.google.security.zynamics.bindiff, NSLocalizedDescription=An error occurred while running scripts from the package “Install BinDiff.pkg”.} {
	    NSFilePath = "./postinstall";
	    NSLocalizedDescription = "An error occurred while running scripts from the package \U201cInstall BinDiff.pkg\U201d.";
	    NSURL = "file:///Users/latortuga0x71/Desktop/Install%20BinDiff.pkg#BinDiff.pkg";
	    PKInstallPackageIdentifier = "com.google.security.zynamics.bindiff";
	}
```