### PR TITLE
Fix names in Primary Unmatched window

### DIFF
--- a/ida/results.cc
+++ b/ida/results.cc
@@ -465,7 +465,7 @@ Results::UnmatchedDescription Results::GetUnmatchedDescription(
   }
 
   const std::string* name = flow_graph_info.demangled_name;
-  if (name == nullptr) {
+  if (name == nullptr || name->empty()) {
     name = flow_graph_info.name;
   }
 


### PR DESCRIPTION
In a C program, all the functions in the Unmatched Primary window are named `sub_XXX`. This is because the real name is stored in `name` and `demangled_name` is set to `""` while `GetUnmatchedDescription` only checks if it is `nullptr`.

This pull request fixes this issue by checking for `""` as well as `nullptr`.