### PR TITLE
Use STL containers when requiring pointer/iterator stability

### DIFF
--- a/differ.h
+++ b/differ.h
@@ -32,7 +32,7 @@ namespace security::bindiff {
 class MatchingContext;
 
 // These need to be sorted
-using Histogram = absl::btree_map<std::string, size_t>;
+using Histogram = std::map<std::string, size_t>;
 using Confidences = absl::btree_map<std::string, double>;
 
 // Main entry point to the differ, runs the core algorithm and produces a

--- a/reader.h
+++ b/reader.h
@@ -32,7 +32,7 @@ struct FlowGraphInfo {
   int edge_count = 0;
   int instruction_count = 0;
 };
-using FlowGraphInfos = absl::btree_map<Address, FlowGraphInfo>;
+using FlowGraphInfos = std::map<Address, FlowGraphInfo>;
 
 struct FixedPointInfo {
   friend bool operator==(const FixedPointInfo& lhs, const FixedPointInfo& rhs) {
@@ -69,7 +69,7 @@ struct FixedPointInfo {
   bool evaluate;
   bool comments_ported;
 };
-using FixedPointInfos = absl::btree_set<FixedPointInfo>;
+using FixedPointInfos = std::set<FixedPointInfo>;
 
 bool operator<(const FixedPointInfo& one, const FixedPointInfo& two);
 


### PR DESCRIPTION
From https://abseil.io/about/design/btree:

> When values are inserted or removed from a B-tree, nodes can be split or merged and values can be moved within and between nodes (for the purpose of maintaining tree balance). This means that when values are inserted or removed from a B-tree container, pointers and iterators to other values in the B-tree can be invalidated. Abseil B-trees therefore do not provide pointer stability or iterator stability - this is in contrast to STL sorted containers that do provide these guarantees.

BinDiff incorrectly relies on pointer stability and iterator stability when using btree data structures in a number of places:
- `indexed_fixed_points_` is a vector of pointers to `FixedPointInfo`s held in a `absl::btree_set`
- `indexed_flow_graphs1_` and `indexed_flow_graphs2_` are vectors of pointers to `FlowGraphInfo`s held in a `absl::btree_map`
- `Results::DeleteMatches` calls `histogram_.erase` while iterating over `histogram_` which is a `absl::btree_map`, invalidating the iterator

You can see the effects of these incorrect assumptions by manually removing and adding matches in the IDA plugin. You will see duplicate matches appearing and functions being erased from the database entirely.

This PR fixes the issue by replacing the types that depend on pointer/iterator stability with their STL equivalents.