### PR TITLE
Fix build without IDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,8 @@ cmake -S . -B build/out -G Ninja \
   -DCMAKE_BUILD_TYPE=Release \
   -DCMAKE_INSTALL_PREFIX=build/out \
   -DBINDIFF_BINEXPORT_DIR=build/binexport \
-  -DBINEXPORT_ENABLE_IDAPRO=OFF
+  -DBINEXPORT_ENABLE_IDAPRO=OFF \
+  -DBINDIFF_ENABLE_IDAPRO=OFF
 ```
 
 ### Java GUI and yFiles

--- a/cmake/BinDiffDeps.cmake
+++ b/cmake/BinDiffDeps.cmake
@@ -29,6 +29,8 @@ if(NOT sqlite_POPULATED)
 endif()
 
 # Setup IDA SDK. Uses FindIdaSdk.cmake from BinExport
-find_package(IdaSdk)
+if(BINDIFF_ENABLE_IDAPRO)
+  find_package(IdaSdk)
+endif()
 
 find_package(Protobuf 3.14 REQUIRED) # Make protobuf_generate_cpp available

--- a/cmake/BinDiffOptions.cmake
+++ b/cmake/BinDiffOptions.cmake
@@ -25,6 +25,8 @@ option(BINDIFF_BUILD_TESTING
        "If ON, this will build all of BinDiff's own tests" ${BINDIFF_TOP_LEVEL})
 option(BINDIFF_BUILD_BENCHMARK
        "If this and BINDIFF_BUILD_TESTING is ON, build benchmark tests" OFF)
+option(BINDIFF_ENABLE_IDAPRO
+       "If ON, enable building the IDA Pro plugin" ON)
 
 if(BINDIFF_BUILD_TESTING)
   # Have BinExport download GoogleTest/Benchmark for us


### PR DESCRIPTION
Added a build option `BINDIFF_ENABLE_IDAPRO`.

Fixes #45 