### PR TITLE
Fix MutexLock compilation in main_portable.cc for IDA Pro 9.1 on Windows

### DIFF
--- a/main_portable.cc
+++ b/main_portable.cc
@@ -213,7 +213,7 @@ void DifferThread::operator()() {
     Timer<> timer;
     {
       // Pop pair from todo queue.
-      absl::MutexLock lock(g_queue_mutex);
+      absl::MutexLock lock(&g_queue_mutex);
       if (file_queue_->empty()) {
         break;
       }


### PR DESCRIPTION
**Description:**  
When building BinDiff from source on Windows for IDA Pro 9.1, compilation fails in main_portable.cc at line 216 with error C2664: Cannot convert 'absl::Mutex' to 'absl::Mutex*'.

The line is: `absl::MutexLock lock(g_queue_mutex);`

This is because the absl::MutexLock constructor requires a pointer to Mutex.

Fix: Change to `absl::MutexLock lock(&g_queue_mutex);`

Tested on: Windows 10, Visual Studio 2019, CMake 4.2.3.

This fixes the build successfully. Solves for https://github.com/google/bindiff/issues/84